### PR TITLE
Uncommenting sealed moves

### DIFF
--- a/DataManager/Characters/Move.cs
+++ b/DataManager/Characters/Move.cs
@@ -27,6 +27,6 @@ namespace DataManager.Characters
         public int MoveNum { get; set; }
         public int CurrentPP { get; set; }
         public int MaxPP { get; set; } 
-        //public bool Sealed { get; set; } 
+        public bool Sealed { get; set; } 
     }
 }


### PR DESCRIPTION
Logically, sealed moves can still be accessed, therefore this line should be uncommented.
