### PR TITLE
fixing colors

### DIFF
--- a/Core/Text.cs
+++ b/Core/Text.cs
@@ -34,6 +34,7 @@ namespace Server
         static Color brightGreen = System.Drawing.Color.LightGreen;
         static Color brightRed = System.Drawing.Color.Red;
         static Color brown = System.Drawing.Color.Brown;
+        static Color orange = System.Drawing.Color.Orange;
         static Color cyan = System.Drawing.Color.Cyan;
         static Color darkGrey = System.Drawing.Color.DarkGray;
         static Color green = System.Drawing.Color.Green;
@@ -82,6 +83,11 @@ namespace Server
         public static Color Brown
         {
             get { return brown; }
+        }
+
+        public static Color Orange
+        {
+            get { return orange; }
         }
 
         public static Color Cyan

--- a/Server/Players/Ranks.cs
+++ b/Server/Players/Ranks.cs
@@ -74,11 +74,11 @@ namespace Server.Players
                 case Enums.Rank.Normal:
                     return Color.Brown;
                 case Enums.Rank.Moniter:
-                    return Color.FromArgb(255, 254, 150, 46);
+                    return Color.Orange;
                 case Enums.Rank.Mapper:
                     return Color.Cyan;
                 case Enums.Rank.Developer:
-                    return Color.FromArgb(255, 0, 110, 210);
+                    return Color.Blue;
                 case Enums.Rank.Admin:
                     return Color.Pink;
                 case Enums.Rank.ServerHost:


### PR DESCRIPTION
Added an "orange" color (would've deleted brightRed but I'm not sure if that would break anything else), made the Moderator rank directly pull that same orange, and made the Developer rank directly pull the blue color.
